### PR TITLE
fix sql error where table field_blog_comments doesn't exist

### DIFF
--- a/ProcessBlog.module
+++ b/ProcessBlog.module
@@ -859,30 +859,34 @@ class ProcessBlog extends Process implements Module, ConfigurableModule {
 		$pendingComment = 0;
 		$spamComment	= -2;
 
+		$numTotal = 0;
 		$database = $this->wire('database');
-		$table = $database->escapeTable('field_blog_comments');// see /wire/core/Fieldtype.php. returns 'field_name_of_field' (i.e. as in the database)
 
-		$sql = "SELECT COUNT(*) FROM `$table` WHERE status=:status";
+		if ($this->commentsUse) {
+			$table = $database->escapeTable('field_blog_comments');// see /wire/core/Fieldtype.php. returns 'field_name_of_field' (i.e. as in the database)
 
-		$query = $database->prepare($sql);// prepare statement
+			$sql = "SELECT COUNT(*) FROM `$table` WHERE status=:status";
+
+			$query = $database->prepare($sql);// prepare statement
 	
-		// approved comments count
-		$query->bindValue(":status", $approvedComment, PDO::PARAM_INT);
-		$query->execute();// execute our count
-		$numApproved = $query->fetchColumn();// fetch the count
+			// approved comments count
+			$query->bindValue(":status", $approvedComment, PDO::PARAM_INT);
+			$query->execute();// execute our count
+			$numApproved = $query->fetchColumn();// fetch the count
 
-		// pending comments count
-		$query->bindValue(":status", $pendingComment, PDO::PARAM_INT);
-		$query->execute();// execute our count
-		$numPending = $query->fetchColumn();// fetch the count
+			// pending comments count
+			$query->bindValue(":status", $pendingComment, PDO::PARAM_INT);
+			$query->execute();// execute our count
+			$numPending = $query->fetchColumn();// fetch the count
 
-		// spam comments count
-		$query->bindValue(":status", $spamComment, PDO::PARAM_INT);
-		$query->execute();// execute our count
-		$numSpam = $query->fetchColumn();// fetch the count
+			// spam comments count
+			$query->bindValue(":status", $spamComment, PDO::PARAM_INT);
+			$query->execute();// execute our count
+			$numSpam = $query->fetchColumn();// fetch the count
 		
-		$numTotal = $numApproved + $numPending + $numSpam;
-		
+			$numTotal = $numApproved + $numPending + $numSpam;
+		}		
+
 		// TABLE for quick view of posts
 
 		// prepare some variables we'll use here


### PR DESCRIPTION
When comments are disabled and I access Blog Dashboard, I receive the following error:

```
ProcessWire: ProcessBlog: SQLSTATE[42S02]: 
Base table or view not found: Table 'xxx.field_blog_comments' doesn't exist
```

I know, this module isn't flagged as ProcessWire 3.x ready, but I want to tell you anyway: **JqueryFancybox** isn't part of the Jquery core module anymore. I added this module manually and now the dashboard works as expected. Maybe you would suggest using **JqueryMagnific** instead in a 3.x ready release, which still is part of the core.
